### PR TITLE
Make truffle-config better for bundling

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ function Config(truffle_directory, working_directory, network) {
     artifactor: null,
     ethpm: {
       ipfs_host: "ipfs.infura.io",
-      ipfs_port: 443,
       ipfs_protocol: "https",
       registry: "0x8011df4830b4f696cd81393997e5371b93338878",
       install_provider_uri: "https://ropsten.infura.io/truffle"

--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ var _ = require("lodash");
 var path = require("path");
 var Provider = require("truffle-provider");
 var TruffleError = require("truffle-error");
-var requireNoCache = require("require-nocache")(module);
+var Module = require('module');
 var findUp = require("find-up");
+var originalrequire = require("original-require");
 
 var DEFAULT_CONFIG_FILENAME = "truffle.js";
 var BACKUP_CONFIG_FILENAME = "truffle-config.js"; // For Windows + Command Prompt
@@ -32,6 +33,7 @@ function Config(truffle_directory, working_directory, network) {
     artifactor: null,
     ethpm: {
       ipfs_host: "ipfs.infura.io",
+      ipfs_port: 443,
       ipfs_protocol: "https",
       registry: "0x8011df4830b4f696cd81393997e5371b93338878",
       install_provider_uri: "https://ropsten.infura.io/truffle"
@@ -241,7 +243,10 @@ Config.load = function(file, options) {
 
   config.working_directory = path.dirname(path.resolve(file));
 
-  var static_config = requireNoCache(file);
+  // The require-nocache module used to do this for us, but
+  // it doesn't bundle very well. So we've pulled it out ourselves.
+  delete require.cache[Module._resolveFilename(file, module)];
+  var static_config = originalrequire(file);
 
   config.merge(static_config);
   config.merge(options);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "find-up": "^2.1.0",
     "lodash": "^4.17.4",
-    "require-nocache": "^1.0.0",
+    "original-require": "^1.0.0",
     "truffle-error": "0.0.2",
     "truffle-provider": "0.0.1"
   }


### PR DESCRIPTION
- Don’t use `require-nocache` anymore, as it uses `module.require` to
do its requiring, which doesn’t work in a bundled context.

- Do what `require-nocache` did for us ourselves, and use the
`original-require` module so we can ensure the bundler ignores that
dependency. (Aside: the `original-require` module is a module I just
made whose code consists of solely `module.exports = require;`.
Separating it allows us to easily ignore the dependency when bundling).