### PR TITLE
Test provider connection and fail early

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,14 @@ function Config(truffle_directory, working_directory, network) {
 
         var options = self.network_config;
         options.verboseRpc = self.verboseRpc;
-        return Provider.create(options);
+
+        var provider =  Provider.create(options);
+
+        Provider.test_connection(provider, function(error, coinbase) {
+          throw error;
+        });
+
+        return provider;
       },
       set: function(val) {
         throw new Error("Don't set config.provider directly. Instead, set config.networks and then set config.networks[<network name>].provider")

--- a/index.js
+++ b/index.js
@@ -154,7 +154,9 @@ function Config(truffle_directory, working_directory, network) {
         var provider =  Provider.create(options);
 
         Provider.test_connection(provider, function(error, coinbase) {
-          throw error;
+          if (error != null) {
+            throw error;
+          }
         });
 
         return provider;


### PR DESCRIPTION
Ref: trufflesuite/truffle#421

Example output after change:

```
/Users/gnidan/tmp/truffle/truffle-config/index.js:157
          throw error;
          ^

Error: Could not connect to your RPC client. Please check your RPC configuration.
    at /Users/gnidan/tmp/truffle/truffle-provider/index.js:53:17
    at /Users/gnidan/tmp/truffle/truffle-provider/node_modules/web3/lib/web3/property.js:119:13
    at /Users/gnidan/tmp/truffle/truffle-provider/node_modules/web3/lib/web3/requestmanager.js:82:20
    at XMLHttpRequest.request.onreadystatechange (/Users/gnidan/tmp/truffle/truffle-provider/node_modules/web3/lib/web3/httpprovider.js:118:13)
    at XMLHttpRequestEventTarget.dispatchEvent (/Users/gnidan/tmp/truffle/truffle-provider/node_modules/xhr2/lib/xhr2.js:64:18)
    at XMLHttpRequest._setReadyState (/Users/gnidan/tmp/truffle/truffle-provider/node_modules/xhr2/lib/xhr2.js:354:12)
    at XMLHttpRequest._onHttpRequestError (/Users/gnidan/tmp/truffle/truffle-provider/node_modules/xhr2/lib/xhr2.js:544:12)
    at ClientRequest.<anonymous> (/Users/gnidan/tmp/truffle/truffle-provider/node_modules/xhr2/lib/xhr2.js:414:24)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
```