### PR TITLE
Add solc settings for optimizer to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ function Config(truffle_directory, working_directory, network) {
       registry: "0x8011df4830b4f696cd81393997e5371b93338878",
       install_provider_uri: "https://ropsten.infura.io/truffle"
     },
+    solc: {
+      optimizer: {
+        enabled: true,
+        runs: 200
+      }
+    },
     logger: {
       log: function() {},
     }
@@ -53,6 +59,7 @@ function Config(truffle_directory, working_directory, network) {
     resolver: function() {},
     artifactor: function() {},
     ethpm: function() {},
+    solc: function() {},
     logger: function() {},
 
     build_directory: function() {


### PR DESCRIPTION
Ref: trufflesuite/truffle#486

This defaults the optimizer **enabled**, runs estimation **200**