### PR TITLE
Disable optimizer by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function Config(truffle_directory, working_directory, network) {
     },
     solc: {
       optimizer: {
-        enabled: true,
+        enabled: false,
         runs: 200
       }
     },

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function Config(truffle_directory, working_directory, network) {
   var self = this;
 
   var default_tx_values = {
-    gas: 4712388,
+    gas: 6721975,
     gasPrice: 100000000000, // 100 Shannon,
     from: null
   };


### PR DESCRIPTION
trufflesuite/truffle#543

- Turn off optimizer as default
- Increase default gas limit (to the current mainnet norm)

(Tested: before updating gas limit, I observed test failures for react-box, fixed when I set the ~6.7M limit)