### PR TITLE
Search for both config variations at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,22 +227,16 @@ Config.default = function() {
 };
 
 Config.detect = function(options, filename) {
-  // Only attempt to detect the backup if a specific file wasn't asked for.
-  var checkBackup = false;
+  var search;
 
-  if (filename == null) {
-    filename = DEFAULT_CONFIG_FILENAME;
-    checkBackup = true;
-  }
+  (filename == null)
+    ? search = [DEFAULT_CONFIG_FILENAME, BACKUP_CONFIG_FILENAME]
+    : search = filename;
 
-  var file = findUp.sync(filename, {cwd: options.working_directory || options.workingDirectory});
+  var file = findUp.sync(search, {cwd: options.working_directory || options.workingDirectory});
 
   if (file == null) {
-    if (checkBackup == true) {
-      return this.detect(options, BACKUP_CONFIG_FILENAME);
-    } else {
-      throw new TruffleError("Could not find suitable configuration file.");
-    }
+    throw new TruffleError("Could not find suitable configuration file.");
   }
 
   return this.load(file, options);

--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ Config.default = function() {
 Config.detect = function(options, filename) {
   var search;
 
-  (filename == null)
+  (!filename)
     ? search = [DEFAULT_CONFIG_FILENAME, BACKUP_CONFIG_FILENAME]
     : search = filename;
 


### PR DESCRIPTION
Addresses [truffle 838](https://github.com/trufflesuite/truffle/issues/838). 

The current `find-up` logic searches the entire directory structure looking for a suitable `truffle.js`, then starts over and looks for `truffle-config.js`. This causes problems if a project (like Zeppelin) has opted to use `truffle-config.js` and an engineer (like Ben Burns) has a `truffle.js` somewhere above the installed project in their path to root. Truffle will locate the wrong`truffle.js` and become incredibly confused. 

[Link](https://www.npmjs.com/package/find-up#api) to the `find-up` API.