### PR TITLE
Make solc evmVersion configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function Config(truffle_directory, working_directory, network) {
       optimizer: {
         enabled: false,
         runs: 200
-      }
+      },
+      evmVersion: "byzantium"
     },
     logger: {
       log: function() {},


### PR DESCRIPTION
[truffle-compile 72](https://github.com/trufflesuite/truffle-compile/issues/72).

Default is `byzantium`. [Input at Solidity](https://solidity.readthedocs.io/en/v0.4.24/using-the-compiler.html#input-description) for reference.